### PR TITLE
Modularize EMA/SMA trading bot into importable scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # alpaca-bot
-Bot for stock trading with Alpaca
+
+This repository contains a Deepnote-authored Jupyter notebook that implements a live trading bot for the SOXL ETF using Alpaca's REST and streaming APIs. The notebook seeds EMA(10) and SMA(50) indicators with early-morning REST bar data, subscribes to minute bars via `StockDataStream`, and routes each update through an asynchronous `handle_trade` routine. There the indicators are refreshed and the bot delegates to `execute_trade_logic`, which decides between holding SOXL or its inverse SOXS based on EMA/SMA crossovers.
+
+The trading logic liquidates opposing positions when signals flip, waits for buying power to reset, and then deploys roughly 90% of available cash on the bullish or bearish leg. Supporting coroutines—such as `clear_all_positions` to flatten exposure near the close—and the `main` entry point orchestrate the websocket event loop with `asyncio.run`. The notebook's dependencies span Alpaca SDKs, technical indicator libraries (`talipp`, `ta`), and plotting/GUI packages like `bokeh`, `mplfinance`, and `PyQt5` to accommodate both trading automation and visualization needs.
+
+## Modular Python scripts
+
+Alongside the notebook, the repository now includes a lightweight module that mirrors the notebook's functionality while exposing reusable components:
+
+- `config.py` centralizes credentials and strategy knobs (tickers, indicator periods, allocation rules).
+- `broker.py` wraps Alpaca's REST and streaming clients so strategies can work against a minimal trading interface.
+- `indicators.py` houses an `IndicatorSet` helper to seed and update EMA/SMA/ATR state.
+- `risk.py` collects reusable routines for buying-power polling and position flattening.
+- `strategy.py` ports the EMA/SMA crossover rules into an importable class with an `on_bar` hook.
+- `runner.py` wires the pieces together, seeds indicators with historical data, and starts the websocket stream.
+
+Importing these scripts lets you adjust tickers or trading criteria through configuration rather than editing notebook cells, paving the way for packaging the bot like other open-source trading projects.

--- a/broker.py
+++ b/broker.py
@@ -1,0 +1,119 @@
+"""Alpaca broker service that wraps REST and streaming clients."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Iterable
+
+from alpaca.data import StockHistoricalDataClient
+from alpaca.data.live import StockDataStream
+from alpaca.data.requests import StockBarsRequest
+from alpaca.data.timeframe import TimeFrame
+from alpaca.trading.client import TradingClient
+from alpaca.trading.enums import OrderSide, TimeInForce
+from alpaca.trading.requests import MarketOrderRequest
+from alpaca.trading.stream import AccountUpdates
+
+from config import AlpacaCredentials, StrategyConfig
+
+
+class AlpacaBroker:
+    """Facade over Alpaca trading and market-data clients."""
+
+    def __init__(self, credentials: AlpacaCredentials, strategy: StrategyConfig):
+        self._strategy = strategy
+        self._trading = TradingClient(
+            api_key=credentials.key_id,
+            secret_key=credentials.secret_key,
+            paper=credentials.paper,
+        )
+        self._data = StockHistoricalDataClient(
+            credentials.key_id, credentials.secret_key
+        )
+        self._stream = StockDataStream(
+            credentials.key_id, credentials.secret_key, paper=credentials.paper
+        )
+
+    # ------------------------------------------------------------------
+    # Trading REST operations
+    def get_account(self):
+        return self._trading.get_account()
+
+    def get_positions(self):
+        return {pos.symbol: pos for pos in self._trading.get_all_positions()}
+
+    def get_position(self, symbol: str):
+        try:
+            return self._trading.get_open_position(symbol)
+        except Exception:  # Alpaca raises APIError when no position exists
+            return None
+
+    def submit_market_order(self, *, symbol: str, qty: int, side: OrderSide,
+                             time_in_force: TimeInForce) -> Any:
+        request = MarketOrderRequest(
+            symbol=symbol,
+            qty=qty,
+            side=side,
+            time_in_force=time_in_force,
+        )
+        return self._trading.submit_order(request)
+
+    def close_position(self, symbol: str):
+        try:
+            self._trading.close_position(symbol)
+        except Exception:
+            pass
+
+    def close_all_positions(self):
+        try:
+            self._trading.close_all_positions(cancel_orders=True)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Market data REST operations
+    def get_seed_bars(self, symbol: str, limit: int) -> list:
+        request = StockBarsRequest(
+            symbol_or_symbols=symbol,
+            timeframe=TimeFrame.Minute,
+            limit=limit,
+        )
+        bars = self._data.get_stock_bars(request)
+        if hasattr(bars, "data"):
+            return list(bars.data.get(symbol, []))
+        if isinstance(bars, dict):
+            return list(bars.get(symbol, []))
+        if isinstance(bars, Iterable):
+            return list(bars)
+        return []
+
+    # ------------------------------------------------------------------
+    # Streaming interface
+    def subscribe_bars(self, handler: Callable[[Any], Awaitable[None]], *symbols: str):
+        self._stream.subscribe_bars(handler, *symbols)
+
+    def subscribe_account_updates(self, handler: Callable[[AccountUpdates], Awaitable[None]]):
+        self._stream.subscribe_trade_updates(handler)
+
+    async def run_stream(self):
+        await self._stream.run()
+
+    async def stop_stream(self):
+        await self._stream.stop()
+
+    async def ensure_stream_running(self):
+        if self._stream._running:  # type: ignore[attr-defined]
+            return
+        await self._stream.run()
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    def to_time_in_force(self, value: str) -> TimeInForce:
+        return TimeInForce(value.upper())
+
+    @property
+    def strategy(self) -> StrategyConfig:
+        return self._strategy
+
+    @property
+    def stream(self) -> StockDataStream:
+        return self._stream

--- a/config.py
+++ b/config.py
@@ -1,0 +1,90 @@
+"""Configuration objects for Alpaca trading strategies."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import time, timedelta
+from typing import List, Sequence
+
+
+@dataclass(slots=True)
+class StreamConfig:
+    """Settings for the market data stream."""
+
+    symbols: Sequence[str] = field(default_factory=lambda: ["SOXL"])
+    reconnect_delay: float = 5.0
+
+
+@dataclass(slots=True)
+class RiskConfig:
+    """Risk management parameters for the strategy."""
+
+    max_position_age: timedelta = timedelta(hours=6)
+    close_all_at: time | None = time(hour=15, minute=55)
+    buying_power_timeout: timedelta = timedelta(seconds=30)
+    buying_power_poll_interval: float = 2.0
+
+
+@dataclass(slots=True)
+class IndicatorConfig:
+    """Indicator lookback windows and behaviour."""
+
+    ema_period: int = 10
+    sma_period: int = 50
+    atr_period: int = 14
+    seed_bars: int = 100
+
+
+@dataclass(slots=True)
+class AllocationConfig:
+    """Settings used to derive order quantities."""
+
+    cash_fraction: float = 0.9
+    order_time_in_force: str = "day"
+
+
+@dataclass(slots=True)
+class StrategyConfig:
+    """Bundle of configuration used by the EMA/SMA strategy."""
+
+    bullish_symbol: str = "SOXL"
+    bearish_symbol: str = "SOXS"
+    stream: StreamConfig = field(default_factory=StreamConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)
+    indicators: IndicatorConfig = field(default_factory=IndicatorConfig)
+    allocation: AllocationConfig = field(default_factory=AllocationConfig)
+
+    def all_symbols(self) -> List[str]:
+        symbols: List[str] = list(dict.fromkeys(
+            [self.bullish_symbol, self.bearish_symbol, *self.stream.symbols]
+        ))
+        return symbols
+
+
+@dataclass(slots=True)
+class AlpacaCredentials:
+    """Container for Alpaca API credentials."""
+
+    key_id: str
+    secret_key: str
+    paper: bool = True
+
+    @classmethod
+    def from_env(cls) -> "AlpacaCredentials":
+        import os
+
+        key_id = os.environ["ALPACA_K"]
+        secret_key = os.environ["ALPACA_SK"]
+        paper = os.environ.get("ALPACA_PAPER", "true").lower() != "false"
+        return cls(key_id=key_id, secret_key=secret_key, paper=paper)
+
+
+@dataclass(slots=True)
+class AppConfig:
+    """Top-level configuration for the trading application."""
+
+    credentials: AlpacaCredentials
+    strategy: StrategyConfig = field(default_factory=StrategyConfig)
+
+    @classmethod
+    def from_env(cls) -> "AppConfig":
+        return cls(credentials=AlpacaCredentials.from_env())

--- a/indicators.py
+++ b/indicators.py
@@ -1,0 +1,42 @@
+"""Indicator management for the EMA/SMA crossover strategy."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from talipp.indicators import ATR, EMA, SMA
+
+
+@dataclass(slots=True)
+class IndicatorSet:
+    """Holds indicator instances and provides update helpers."""
+
+    ema: EMA
+    sma: SMA
+    atr: ATR
+
+    @classmethod
+    def from_config(cls, *, ema_period: int, sma_period: int, atr_period: int) -> "IndicatorSet":
+        return cls(EMA(ema_period), SMA(sma_period), ATR(atr_period))
+
+    def seed_from_bars(self, bars: Iterable):
+        for bar in bars:
+            price = getattr(bar, "close", None)
+            if price is None:
+                continue
+            self.ema.add_input_value(price)
+            self.sma.add_input_value(price)
+            self.atr.add_input_value(bar)
+
+    def update_from_bar(self, bar) -> None:
+        self.ema.add_input_value(bar.close)
+        self.sma.add_input_value(bar.close)
+        self.atr.add_input_value(bar)
+
+    @property
+    def latest_ema(self) -> float | None:
+        return self.ema[-1] if len(self.ema) else None
+
+    @property
+    def latest_sma(self) -> float | None:
+        return self.sma[-1] if len(self.sma) else None

--- a/risk.py
+++ b/risk.py
@@ -1,0 +1,54 @@
+"""Risk management helpers used by the trading strategy."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, time
+from typing import Optional
+
+from alpaca.trading.enums import OrderSide
+
+from config import RiskConfig
+
+
+class RiskManager:
+    """Collection of risk-related checks and routines."""
+
+    def __init__(self, broker, config: RiskConfig):
+        self._broker = broker
+        self._config = config
+
+    async def wait_for_buying_power(self, required_cash: float) -> bool:
+        """Poll the account until buying power covers the required cash."""
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + self._config.buying_power_timeout.total_seconds()
+        while loop.time() < deadline:
+            account = self._broker.get_account()
+            if float(account.buying_power) >= required_cash:
+                return True
+            await asyncio.sleep(self._config.buying_power_poll_interval)
+        return False
+
+    def should_flatten_positions(self, now: Optional[datetime] = None) -> bool:
+        if self._config.close_all_at is None:
+            return False
+        now = now or datetime.now()
+        cutoff = self._config.close_all_at
+        return time(now.hour, now.minute) >= cutoff
+
+    def flatten_positions(self):
+        self._broker.close_all_positions()
+
+    async def ensure_no_opposite_position(self, hedge_symbol: str):
+        hedge_position = self._broker.get_position(hedge_symbol)
+        if hedge_position:
+            qty = int(float(hedge_position.qty))
+            if qty:
+                side = OrderSide.SELL if qty > 0 else OrderSide.BUY
+                self._broker.submit_market_order(
+                    symbol=hedge_symbol,
+                    qty=abs(qty),
+                    side=side,
+                    time_in_force=self._broker.to_time_in_force(
+                        self._broker.strategy.allocation.order_time_in_force
+                    ),
+                )

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,49 @@
+"""Application entry-point that wires configuration, broker, and strategy."""
+from __future__ import annotations
+
+import asyncio
+
+from alpaca.data.models import Bar
+
+from broker import AlpacaBroker
+from config import AppConfig
+from indicators import IndicatorSet
+from risk import RiskManager
+from strategy import EmaSmaStrategy
+
+
+def build_app(config: AppConfig) -> tuple[AlpacaBroker, EmaSmaStrategy]:
+    broker = AlpacaBroker(config.credentials, config.strategy)
+    indicators = IndicatorSet.from_config(
+        ema_period=config.strategy.indicators.ema_period,
+        sma_period=config.strategy.indicators.sma_period,
+        atr_period=config.strategy.indicators.atr_period,
+    )
+    risk = RiskManager(broker, config.strategy.risk)
+    strategy = EmaSmaStrategy(broker, indicators, risk)
+
+    seed_symbol = config.strategy.bullish_symbol
+    seed_bars = broker.get_seed_bars(seed_symbol, config.strategy.indicators.seed_bars)
+    indicators.seed_from_bars(seed_bars)
+
+    async def handle_bar(bar: Bar):
+        await strategy.on_bar(bar)
+
+    symbols = config.strategy.stream.symbols or [seed_symbol]
+    broker.subscribe_bars(handle_bar, *symbols)
+
+    return broker, strategy
+
+
+async def run(config: AppConfig) -> None:
+    broker, _ = build_app(config)
+    await broker.run_stream()
+
+
+def main() -> None:
+    config = AppConfig.from_env()
+    asyncio.run(run(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategy.py
+++ b/strategy.py
@@ -1,0 +1,85 @@
+"""EMA/SMA crossover trading strategy implementation."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from alpaca.data.models import Bar
+from alpaca.trading.enums import OrderSide
+
+from broker import AlpacaBroker
+from indicators import IndicatorSet
+from risk import RiskManager
+
+
+class EmaSmaStrategy:
+    """Implements the SOXL/SOXS crossover logic from the notebook."""
+
+    def __init__(self, broker: AlpacaBroker, indicators: IndicatorSet, risk: RiskManager):
+        self._broker = broker
+        self._config = broker.strategy
+        self._indicators = indicators
+        self._risk = risk
+
+    async def on_bar(self, bar: Bar):
+        self._indicators.update_from_bar(bar)
+
+        ema = self._indicators.latest_ema
+        sma = self._indicators.latest_sma
+        if ema is None or sma is None:
+            return
+
+        # Flatten positions when approaching the configured cutoff.
+        if self._risk.should_flatten_positions(self._timestamp_to_datetime(bar.timestamp)):
+            self._risk.flatten_positions()
+            return
+
+        if ema > sma:
+            await self._enter_symbol(
+                target_symbol=self._config.bullish_symbol,
+                hedge_symbol=self._config.bearish_symbol,
+                last_price=bar.close,
+                side=OrderSide.BUY,
+            )
+        elif ema < sma:
+            await self._enter_symbol(
+                target_symbol=self._config.bearish_symbol,
+                hedge_symbol=self._config.bullish_symbol,
+                last_price=bar.close,
+                side=OrderSide.BUY,
+            )
+
+    async def _enter_symbol(self, *, target_symbol: str, hedge_symbol: str, last_price: float, side: OrderSide) -> None:
+        await self._risk.ensure_no_opposite_position(hedge_symbol)
+
+        account = self._broker.get_account()
+        buying_power = float(account.buying_power)
+        allocation = buying_power * self._config.allocation.cash_fraction
+        quantity = int(allocation // last_price)
+        if quantity <= 0:
+            return
+
+        if not await self._risk.wait_for_buying_power(quantity * last_price):
+            return
+
+        existing_position = self._broker.get_position(target_symbol)
+        if existing_position and int(float(existing_position.qty)) > 0:
+            return
+
+        self._broker.submit_market_order(
+            symbol=target_symbol,
+            qty=quantity,
+            side=side,
+            time_in_force=self._broker.to_time_in_force(self._config.allocation.order_time_in_force),
+        )
+
+    @staticmethod
+    def _timestamp_to_datetime(ts) -> Optional[datetime]:
+        if ts is None:
+            return None
+        if isinstance(ts, datetime):
+            return ts
+        try:
+            return datetime.fromisoformat(str(ts))
+        except Exception:
+            return None


### PR DESCRIPTION
## Summary
- add configuration, broker, indicator, risk, strategy, and runner modules derived from the notebook logic
- document the new modular scripts in the README for easier discovery

## Testing
- python -m compileall broker.py config.py indicators.py risk.py strategy.py runner.py

------
https://chatgpt.com/codex/tasks/task_e_68dc7ebb0dc0832aa65fc40336e99602