### PR TITLE
Restyle live trading reference notebook

### DIFF
--- a/LiveTrading_Modular_Reference.ipynb
+++ b/LiveTrading_Modular_Reference.ipynb
@@ -1,0 +1,417 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style=\"padding: 2.25rem 2.5rem; border-radius: 18px; background: linear-gradient(120deg, #0b1220, #132c55); color: #f4f7fb; box-shadow: 0 18px 40px rgba(4,19,43,0.45);\">\n",
+    "  <h1 style=\"margin-top: 0; font-size: 2.4rem; letter-spacing: 0.02em;\">Live Trading Modular Reference</h1>\n",
+    "  <p style=\"font-size: 1.05rem; line-height: 1.6; max-width: 960px;\">\n",
+    "    This notebook is a field guide for the live Alpaca trading bot. Use it during <strong>real market sessions</strong> to inspect configuration, verify broker connectivity, and launch the live data stream without touching simulation tooling.\n",
+    "  </p>\n",
+    "  <div style=\"display: flex; flex-wrap: wrap; gap: 1rem;\">\n",
+    "    <div style=\"flex: 1 1 240px; background: rgba(255,255,255,0.06); border-radius: 14px; padding: 1rem 1.2rem;\">\n",
+    "      <strong>Modular Focus</strong>\n",
+    "      <p style=\"margin: .35rem 0 0; font-size: .95rem;\">Strategy config \u00b7 Broker facade \u00b7 Indicators \u00b7 Risk</p>\n",
+    "    </div>\n",
+    "    <div style=\"flex: 1 1 240px; background: rgba(255,255,255,0.06); border-radius: 14px; padding: 1rem 1.2rem;\">\n",
+    "      <strong>Audience</strong>\n",
+    "      <p style=\"margin: .35rem 0 0; font-size: .95rem;\">Operators running the bot against live Alpaca endpoints</p>\n",
+    "    </div>\n",
+    "    <div style=\"flex: 1 1 240px; background: rgba(255,255,255,0.06); border-radius: 14px; padding: 1rem 1.2rem;\">\n",
+    "      <strong>Safety First</strong>\n",
+    "      <p style=\"margin: .35rem 0 0; font-size: .95rem;\">Review every step before transmitting an order</p>\n",
+    "    </div>\n",
+    "  </div>\n",
+    "</div>\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### \ud83d\udd17 Quick Navigation\n",
+    "- [1. Environment prerequisites](#1-environment-prerequisites)\n",
+    "- [2. Strategy configuration anatomy](#2-strategy-configuration-anatomy)\n",
+    "- [3. Credential handling & broker facade](#3-credential-handling-and-broker-facade)\n",
+    "- [4. Indicators snapshot](#4-indicators-module-snapshot)\n",
+    "- [5. Risk manager overview](#5-risk-manager-overview)\n",
+    "- [6. Strategy orchestration hooks](#6-strategy-orchestration-hooks)\n",
+    "- [7. Live stream wiring](#7-live-stream-wiring-manual-start)\n",
+    "\n",
+    "> \u26a0\ufe0f <strong>Live Trading Notice:</strong> Cells in this notebook instantiate <em>real</em> broker clients. Confirm credentials, buying power, and open positions before executing anything that places orders.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Environment prerequisites\n",
+    "\n",
+    "<div style=\"padding: 1.2rem 1.4rem; border-left: 6px solid #4c9aff; background: rgba(76,154,255,0.08); border-radius: 0 14px 14px 0;\">\n",
+    "  <strong>Goal:</strong> Authenticate the bot against Alpaca's live trading and market data endpoints.\n",
+    "</div>\n",
+    "\n",
+    "<table>\n",
+    "  <thead>\n",
+    "    <tr><th align=\"left\">Step</th><th align=\"left\">Action</th><th align=\"left\">Notes</th></tr>\n",
+    "  </thead>\n",
+    "  <tbody>\n",
+    "    <tr><td>1</td><td>Export your API keys</td><td>Prefer <code>direnv</code> or secrets manager so they refresh automatically.</td></tr>\n",
+    "    <tr><td>2</td><td>Verify account mode</td><td><code>APCA_API_BASE_URL</code> must point to the live trading URL.</td></tr>\n",
+    "    <tr><td>3</td><td>Double-check equity</td><td>Use the REST client (<code>get_account()</code>) to confirm buying power.</td></tr>\n",
+    "  </tbody>\n",
+    "</table>\n",
+    "\n",
+    "Use the cell below to materialize environment variables in the current kernel session. The helper prints the destination host to confirm you are not on the paper endpoint.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations",
+    "",
+    "import asyncio",
+    "import inspect",
+    "from dataclasses import asdict, fields",
+    "",
+    "import nest_asyncio",
+    "",
+    "from bootstrap import ensure_requirements",
+    "from broker import AlpacaBroker",
+    "from config import AppConfig, AlpacaCredentials, StrategyConfig",
+    "from indicators import IndicatorSet",
+    "from risk import RiskManager",
+    "from strategy import EmaSmaStrategy",
+    "",
+    "# Guarantee compatibility with already-running event loops (common in notebooks)",
+    "nest_asyncio.apply()",
+    "",
+    "# Safety: no automatic installation when running during market hours.",
+    "ensure_requirements(auto_install=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Strategy configuration anatomy\n",
+    "\n",
+    "<div style=\"display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));\">\n",
+    "  <div style=\"padding: 1.2rem 1.4rem; border-radius: 16px; background: #f4f7fb; border: 1px solid #d7e1f5;\">\n",
+    "    <h4 style=\"margin-top: 0;\">Why it matters</h4>\n",
+    "    <p style=\"margin-bottom: 0; font-size: .95rem; line-height: 1.55;\">The <code>StrategyConfig</code> dataclass orchestrates symbols, bar windows, and risk parameters. Keeping it transparent lets you audit live runs rapidly.</p>\n",
+    "  </div>\n",
+    "  <div style=\"padding: 1.2rem 1.4rem; border-radius: 16px; background: #fff0e6; border: 1px solid #ffc9a6;\">\n",
+    "    <h4 style=\"margin-top: 0;\">Refresh cadence</h4>\n",
+    "    <p style=\"margin-bottom: 0; font-size: .95rem; line-height: 1.55;\">Re-evaluate settings before the open, after major macro events, or when swapping strategies.</p>\n",
+    "  </div>\n",
+    "</div>\n",
+    "\n",
+    "| Attribute | Purpose | Live-trading tip |\n",
+    "| --- | --- | --- |\n",
+    "| `symbols` | Tuple of tradable tickers | Keep correlated hedges adjacent for faster updates. |\n",
+    "| `cash_alloc_pct` | Fraction of equity allocated | Cap below 0.9 to reserve dry powder for slippage. |\n",
+    "| `ema_fast` / `ema_slow` | Trend detection windows | Shorten fast EMA in high-volatility regimes. |\n",
+    "| `sma_window` | Mean reversion baseline | Larger windows smooth noise but slow reactions. |\n",
+    "| `atr_window` | Volatility sizing | Inspect ATR values when adjusting stop distances. |\n",
+    "\n",
+    "Use the next cell to surface the current configuration and confirm its runtime values.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strategy_config = StrategyConfig()",
+    "for field in fields(strategy_config):",
+    "    value = getattr(strategy_config, field.name)",
+    "    print(f\"{field.name}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style=\"padding: 1.1rem 1.3rem; background: rgba(32, 201, 151, 0.08); border-left: 6px solid #20c997; border-radius: 0 14px 14px 0;\">\n",
+    "  <strong>Live tweak shortcut:</strong> Override parameters here (e.g., swap tickers or throttle allocation) <em>before</em> instantiating dependent modules below.\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_strategy = StrategyConfig(",
+    "    bullish_symbol=\"SOXL\",",
+    "    bearish_symbol=\"SOXS\",",
+    "    allocation=strategy_config.allocation,",
+    "    indicators=strategy_config.indicators,",
+    "    risk=strategy_config.risk,",
+    "    stream=strategy_config.stream,",
+    ")",
+    "custom_strategy.allocation.cash_fraction = 0.75  # allocate 75% of buying power",
+    "custom_strategy.stream.symbols = [\"SOXL\", \"SOXS\"]",
+    "custom_strategy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Credential handling and broker facade\n",
+    "\n",
+    "<div style=\"display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));\">\n",
+    "  <div style=\"padding: 1.1rem 1.3rem; border-radius: 16px; background: #eef6ff; border: 1px solid #c5e1ff;\">\n",
+    "    <h4 style=\"margin-top: 0;\">Broker toolkit</h4>\n",
+    "    <ul style=\"padding-left: 1.1rem; margin: .4rem 0 0;\">\n",
+    "      <li><code>submit_order()</code> &amp; <code>replace_order()</code></li>\n",
+    "      <li>Live polygon/Alpaca market data stream</li>\n",
+    "      <li>Order-state callbacks for fills and cancels</li>\n",
+    "    </ul>\n",
+    "  </div>\n",
+    "  <div style=\"padding: 1.1rem 1.3rem; border-radius: 16px; background: #fff5f5; border: 1px solid #ffd0d0;\">\n",
+    "    <h4 style=\"margin-top: 0;\">Security checklist</h4>\n",
+    "    <p style=\"margin: 0; font-size: .95rem; line-height: 1.55;\">Rotate API keys regularly and scope them to trading + data only. Never commit credentials\u2014reference environment variables exclusively.</p>\n",
+    "  </div>\n",
+    "</div>\n",
+    "\n",
+    "Inspect the broker instance below to confirm endpoints, subscribed symbols, and current throttle limits before placing live orders.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "credentials = AlpacaCredentials.from_env()",
+    "app_config = AppConfig(credentials=credentials, strategy=custom_strategy)",
+    "broker = AlpacaBroker(app_config.credentials, app_config.strategy)",
+    "",
+    "# Summarize the key callable broker methods for quick reference.",
+    "broker_operations = {",
+    "    name: obj",
+    "    for name, obj in inspect.getmembers(broker, predicate=callable)",
+    "    if not name.startswith(\"_\")",
+    "}",
+    "list(broker_operations.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style=\"padding: 1.2rem 1.3rem; border-left: 6px solid #a855f7; background: rgba(168, 85, 247, 0.08); border-radius: 0 14px 14px 0;\">\n",
+    "  <strong>Pro tip:</strong> Use <code>print_signature(broker.submit_order)</code> to display argument defaults, ensuring position sizes and time-in-force match your playbook before the opening bell.\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name in [",
+    "    \"get_account\",",
+    "    \"get_positions\",",
+    "    \"submit_market_order\",",
+    "    \"close_position\",",
+    "    \"close_all_positions\",",
+    "    \"subscribe_bars\",",
+    "    \"run_stream\",",
+    "]:",
+    "    func = broker_operations[name]",
+    "    signature = str(inspect.signature(func))",
+    "    doc = inspect.getdoc(func) or \"No docstring.\"",
+    "    print(f\"{name}{signature}",
+    "  {doc}",
+    "\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Indicators module snapshot\n",
+    "\n",
+    "<div style=\"padding: 1.15rem 1.3rem; background: #f5f9ff; border: 1px solid #d8e6ff; border-radius: 16px;\">\n",
+    "  <p style=\"margin: 0; font-size: .97rem; line-height: 1.6;\">\n",
+    "    <strong>IndicatorSet</strong> keeps EMA, SMA, and ATR metrics synchronized with the latest bars. With live data flowing, review the rolling values here to validate the signal regime you're trading in.\n",
+    "  </p>\n",
+    "</div>\n",
+    "\n",
+    "| Metric | Description | Operational use |\n",
+    "| --- | --- | --- |\n",
+    "| EMA fast/slow | Trend accelerators | Confirm crossovers align with your manual charting. |\n",
+    "| SMA baseline | Long-term drift | Use as bias filter to avoid counter-trend orders. |\n",
+    "| ATR window | Volatility proxy | Scale stop-losses and position sizes responsively. |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indicators = IndicatorSet.from_config(",
+    "    ema_period=app_config.strategy.indicators.ema_period,",
+    "    sma_period=app_config.strategy.indicators.sma_period,",
+    "    atr_period=app_config.strategy.indicators.atr_period,",
+    ")",
+    "",
+    "seed_bars = broker.get_seed_bars(",
+    "    app_config.strategy.bullish_symbol,",
+    "    app_config.strategy.indicators.seed_bars,",
+    ")",
+    "indicators.seed_from_bars(seed_bars)",
+    "",
+    "print(\"Latest EMA:\", indicators.latest_ema)",
+    "print(\"Latest SMA:\", indicators.latest_sma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Risk manager overview\n",
+    "\n",
+    "<div style=\"display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));\">\n",
+    "  <div style=\"padding: 1.1rem 1.3rem; border-radius: 16px; background: #f3fff8; border: 1px solid #c9f7d6;\">\n",
+    "    <h4 style=\"margin-top: 0;\">Automated guardrails</h4>\n",
+    "    <ul style=\"margin: .4rem 0 0; font-size: .95rem; line-height: 1.55;\">\n",
+    "      <li>Flatten near close</li>\n",
+    "      <li>Buying power validation</li>\n",
+    "      <li>Dynamic hedge toggles</li>\n",
+    "    </ul>\n",
+    "  </div>\n",
+    "  <div style=\"padding: 1.1rem 1.3rem; border-radius: 16px; background: #fff4e8; border: 1px solid #ffd9b5;\">\n",
+    "    <h4 style=\"margin-top: 0;\">Operator checklist</h4>\n",
+    "    <ul style=\"margin: .4rem 0 0; font-size: .95rem; line-height: 1.55;\">\n",
+    "      <li>Inspect max drawdown thresholds</li>\n",
+    "      <li>Confirm trading hours boundaries</li>\n",
+    "      <li>Simulate risk adjustments on small size first</li>\n",
+    "    </ul>\n",
+    "  </div>\n",
+    "</div>\n",
+    "\n",
+    "Use the following cell to introspect callable methods and adjust risk toggles while monitoring fills.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "risk_manager = RiskManager(broker, app_config.strategy.risk)",
+    "",
+    "risk_summary = asdict(app_config.strategy.risk)",
+    "print(\"Risk configuration:\")",
+    "for key, value in risk_summary.items():",
+    "    print(f\"  {key}: {value}\")",
+    "",
+    "# Display coroutine signatures for situational awareness.",
+    "for name, func in inspect.getmembers(risk_manager, predicate=callable):",
+    "    if name.startswith(\"_\"):",
+    "        continue",
+    "    signature = str(inspect.signature(func))",
+    "    print(f\"RiskManager.{name}{signature}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Strategy orchestration hooks\n",
+    "\n",
+    "<div style=\"padding: 1.2rem 1.3rem; background: rgba(255, 255, 255, 0.65); border-radius: 16px; border: 1px solid #e3e7ef;\">\n",
+    "  <p style=\"margin: 0; font-size: .97rem; line-height: 1.6;\">\n",
+    "    <code>EmaSmaStrategy</code> contains the heart of the crossover logic. The helper below lets you explore lifecycle hooks\u2014<code>on_bar</code>, <code>on_fill</code>, and <code>rebalance_positions</code>\u2014so you can inject logging or additional trade management while markets run.\n",
+    "  </p>\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strategy = EmaSmaStrategy(broker, indicators, risk_manager)",
+    "",
+    "print(\"Strategy is monitoring:\", app_config.strategy.all_symbols())",
+    "print(\"Attributes:\", [name for name in strategy.__dict__.keys() if not name.startswith(\"_\")])",
+    "print(\"Public coroutine methods:\")",
+    "for name, func in inspect.getmembers(strategy, predicate=callable):",
+    "    if name.startswith(\"_\"):",
+    "        continue",
+    "    print(\" -\", name, inspect.signature(func))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Live stream wiring (manual start)\n",
+    "\n",
+    "<div style=\"padding: 1.25rem 1.35rem; border-left: 6px solid #ef4444; background: rgba(239, 68, 68, 0.08); border-radius: 0 14px 14px 0;\">\n",
+    "  <strong>Final gate:</strong> Only execute the streaming cell once all prior inspections are complete and you're ready to react to live bars. Stop with <code>await broker.stop_stream()</code> to pause trading.\n",
+    "</div>\n",
+    "\n",
+    "<div style=\"display: flex; flex-wrap: wrap; gap: 1rem; margin-top: 1rem;\">\n",
+    "  <div style=\"flex: 1 1 260px; padding: 1rem 1.1rem; background: #111827; color: #f9fafb; border-radius: 14px;\">\n",
+    "    <strong>Stream Checklist</strong>\n",
+    "    <ul style=\"margin: .5rem 0 0; padding-left: 1.1rem; line-height: 1.55;\">\n",
+    "      <li>Broker authenticated</li>\n",
+    "      <li>Strategy hooks tested</li>\n",
+    "      <li>Risk boundaries verified</li>\n",
+    "      <li>Logging tailing in terminal</li>\n",
+    "    </ul>\n",
+    "  </div>\n",
+    "  <div style=\"flex: 1 1 260px; padding: 1rem 1.1rem; background: #f5f3ff; border-radius: 14px; border: 1px solid #d8d1ff; color: #1f2937;\">\n",
+    "    <strong>What to monitor</strong>\n",
+    "    <ul style=\"margin: .5rem 0 0; padding-left: 1.1rem; line-height: 1.55;\">\n",
+    "      <li>Fill latency vs. exchange timestamps</li>\n",
+    "      <li>Indicator drift between bars</li>\n",
+    "      <li>Risk manager overrides triggering</li>\n",
+    "    </ul>\n",
+    "  </div>\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def handle_bar(bar):",
+    "    await strategy.on_bar(bar)",
+    "",
+    "broker.subscribe_bars(handle_bar, *app_config.strategy.all_symbols())",
+    "",
+    "# Uncomment the line below to start streaming live market data.",
+    "# await broker.run_stream()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- refresh the live trading modular reference notebook with a hero section, navigation, and callout styling
- add visual tables, checklists, and highlight cards for each module to improve readability during live sessions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9dc958bc832ab1d3a44217121a92