### PR TITLE
Add environment configuration template and gitignore

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Environment variables for Alpaca bot
+# Replace the placeholder values with your actual credentials.
+ALPACA_API_KEY=your_alpaca_api_key_here
+ALPACA_SECRET_KEY=your_alpaca_secret_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore environment variable files containing sensitive data
+.env
+.env.*
+
+# Python cache directories
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- add a .env file with placeholder Alpaca API credentials so secrets can be configured outside the codebase
- introduce a .gitignore entry to prevent environment files and Python caches from being committed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd8633f448832aba93ca4092c50492